### PR TITLE
Add set of price summaries that only reflect current / future prices

### DIFF
--- a/models/analysisPrices.go
+++ b/models/analysisPrices.go
@@ -1,12 +1,12 @@
 package models
 
-type hasPrices interface {
+type HasPrices interface {
 	MinPrice() int
 	GuaranteedPrice() int
 	MaxPrice() int
 }
 
-type prices struct {
+type pricesVal struct {
 	// Price info
 	minPrice        int
 	guaranteedPrice int
@@ -19,7 +19,7 @@ type prices struct {
 }
 
 // The absolute minimum price that may occur.
-func (prices *prices) MinPrice() int {
+func (prices *pricesVal) MinPrice() int {
 	return prices.minPrice
 }
 
@@ -27,17 +27,17 @@ func (prices *prices) MinPrice() int {
 // PotentialPricePeriod objects, this is the *lowest possible price* for the given
 // period, but on Week, Pattern, and Prediction object this is the minimum guaranteed
 // price, or the highest price we can guarantee will occur this week.
-func (prices *prices) GuaranteedPrice() int {
+func (prices *pricesVal) GuaranteedPrice() int {
 	return prices.guaranteedPrice
 }
 
 // The potential maximum price for this period / week / pattern / prediction.
-func (prices *prices) MaxPrice() int {
+func (prices *pricesVal) MaxPrice() int {
 	return prices.maxPrice
 }
 
 // Returns the chance of this price range resulting in this price.
-func (prices *prices) PriceChance(price int) float64 {
+func (prices *pricesVal) PriceChance(price int) float64 {
 	switch {
 	case price == prices.maxPrice:
 		return prices.maxChance
@@ -48,7 +48,7 @@ func (prices *prices) PriceChance(price int) float64 {
 	}
 }
 
-func (prices *prices) updateMin(value int) (updated bool) {
+func (prices *pricesVal) updateMin(value int) (updated bool) {
 	updated = (prices.minPrice == 0 || value < prices.minPrice) && value != 0
 
 	if updated {
@@ -58,7 +58,7 @@ func (prices *prices) updateMin(value int) (updated bool) {
 	return updated
 }
 
-func (prices *prices) updateGuaranteed(value int, useHigher bool) (updated bool) {
+func (prices *pricesVal) updateGuaranteed(value int, useHigher bool) (updated bool) {
 	updated = ((useHigher && value > prices.guaranteedPrice) ||
 		(!useHigher && value < prices.guaranteedPrice) ||
 		prices.guaranteedPrice == 0) &&
@@ -71,7 +71,7 @@ func (prices *prices) updateGuaranteed(value int, useHigher bool) (updated bool)
 	return updated
 }
 
-func (prices *prices) updateMax(value int) (updated bool) {
+func (prices *pricesVal) updateMax(value int) (updated bool) {
 	updated = value > prices.maxPrice
 
 	if updated {
@@ -81,8 +81,8 @@ func (prices *prices) updateMax(value int) (updated bool) {
 	return updated
 }
 
-func (prices *prices) updatePrices(
-	otherPrices hasPrices, useHigherGuaranteed bool,
+func (prices *pricesVal) updatePrices(
+	otherPrices HasPrices, useHigherGuaranteed bool,
 ) (guaranteedUpdated bool, maxUpdated bool, minUpdated bool) {
 	minUpdated = prices.updateMin(otherPrices.MinPrice())
 	guaranteedUpdated = prices.updateGuaranteed(

--- a/models/phaseAutoCalcPeriodGen.go
+++ b/models/phaseAutoCalcPeriodGen.go
@@ -264,7 +264,7 @@ func (gen *phasePeriodGenerator) buildCurrentPeriod() *PotentialPricePeriod {
 	}
 
 	return &PotentialPricePeriod{
-		prices: &prices{
+		pricesVal: &pricesVal{
 			minPrice:        gen.priceMin,
 			guaranteedPrice: gen.priceMin,
 			maxPrice:        gen.priceMax,

--- a/models/potentialPeriod.go
+++ b/models/potentialPeriod.go
@@ -1,7 +1,7 @@
 package models
 
 type PotentialPricePeriod struct {
-	*prices
+	*pricesVal
 	Spikes *SpikeHasAll
 
 	// The price period
@@ -20,6 +20,6 @@ func (potential *PotentialPricePeriod) IsValidPrice(price int) bool {
 		return true
 	}
 
-	return price >= potential.prices.GuaranteedPrice() &&
-		price <= potential.prices.MaxPrice()
+	return price >= potential.pricesVal.GuaranteedPrice() &&
+		price <= potential.pricesVal.MaxPrice()
 }

--- a/models/potentialWeek_test.go
+++ b/models/potentialWeek_test.go
@@ -18,7 +18,7 @@ func newPotentialWeek() *PotentialWeek {
 		Spikes:   nil,
 		Prices: PotentialPricePeriods{
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 100,
 					maxPrice:        100,
 					minChance:       0,
@@ -28,7 +28,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 0,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 101,
 					maxPrice:        101,
 					minChance:       0,
@@ -38,7 +38,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 1,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 102,
 					maxPrice:        102,
 					minChance:       0,
@@ -48,7 +48,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 2,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 103,
 					maxPrice:        103,
 					minChance:       0,
@@ -58,7 +58,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 3,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 104,
 					maxPrice:        104,
 					minChance:       0,
@@ -68,7 +68,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 4,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 105,
 					maxPrice:        105,
 					minChance:       0,
@@ -78,7 +78,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 5,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 106,
 					maxPrice:        106,
 					minChance:       0,
@@ -88,7 +88,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 6,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 107,
 					maxPrice:        107,
 					minChance:       0,
@@ -98,7 +98,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 7,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 108,
 					maxPrice:        108,
 					minChance:       0,
@@ -108,7 +108,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 8,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 109,
 					maxPrice:        109,
 					minChance:       0,
@@ -118,7 +118,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 9,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 110,
 					maxPrice:        110,
 					minChance:       0,
@@ -128,7 +128,7 @@ func newPotentialWeek() *PotentialWeek {
 				PricePeriod: 10,
 			},
 			{
-				prices: &prices{
+				pricesVal: &pricesVal{
 					guaranteedPrice: 111,
 					maxPrice:        111,
 					minChance:       0,

--- a/models/prediction.go
+++ b/models/prediction.go
@@ -19,6 +19,7 @@ func (patterns Patterns) Get(pattern PricePattern) (*PotentialPattern, error) {
 
 type Prediction struct {
 	PriceSeries
+	Future   PriceSeries
 	Spikes   *SpikeChancesAll
 	Patterns Patterns
 }

--- a/models/predictor.go
+++ b/models/predictor.go
@@ -21,6 +21,10 @@ func (predictor *Predictor) increaseBinWidth(amount float64) {
 
 func (predictor *Predictor) Predict() (*Prediction, error) {
 	result := &Prediction{
+		Future: PriceSeries{
+			future:        true,
+			currentPeriod: predictor.Ticker.CurrentPeriod,
+		},
 		Spikes: &SpikeChancesAll{
 			small: &SpikeChance{
 				breakdown: new(SpikeChanceBreakdown),
@@ -54,6 +58,7 @@ func (predictor *Predictor) Predict() (*Prediction, error) {
 		// Integrate this data with our top-level summary
 		result.Patterns = append(result.Patterns, potentialPattern)
 		result.updatePriceRangeFromOther(potentialPattern)
+		result.Future.updatePriceRangeFromOther(&potentialPattern.Future)
 		result.Spikes.updateRanges(potentialPattern.Spikes)
 		predictor.increaseBinWidth(binWidth)
 	}

--- a/models/predictorPattern.go
+++ b/models/predictorPattern.go
@@ -59,6 +59,7 @@ func (predictor *patternPredictor) addWeekFromFinalizedPhases(
 	// Otherwise, add the result and updatePrices all of our pattern's stats
 	result.PotentialWeeks = append(result.PotentialWeeks, potentialWeek)
 	result.updatePriceRangeFromOther(potentialWeek)
+	result.Future.updatePriceRangeFromOther(&potentialWeek.Future)
 	result.Spikes.updateSpikeFromRange(potentialWeek.Spikes)
 	predictor.increaseBinWidth(binWidth)
 }
@@ -142,7 +143,7 @@ func (predictor *patternPredictor) branchPhases(
 
 func (predictor *patternPredictor) setup() {
 	predictor.result = &PotentialPattern{
-		Analysis: new(Analysis),
+		Analysis: NewAnalysis(predictor.Ticker),
 		Pattern:  predictor.Pattern,
 		Spikes: &SpikeRangeAll{
 			big:   new(SpikeRange),

--- a/models/predictorWeek.go
+++ b/models/predictorWeek.go
@@ -96,6 +96,7 @@ func (predictor *weekPredictor) buildWeek() {
 			// We want to find the highest minimum for this potential week and use that
 			// as the week's guaranteed minimum
 			result.updatePriceRangeFromPrices(potentialPeriod, pricePeriod)
+			result.Future.updatePriceRangeFromPrices(potentialPeriod, pricePeriod)
 			result.Spikes.updateSpikeFromPeriod(
 				potentialPeriod.PricePeriod, potentialPeriod.Spikes,
 			)
@@ -128,7 +129,7 @@ func (predictor *weekPredictor) finalizeWidth() {
 
 func (predictor *weekPredictor) setup() {
 	predictor.result = &PotentialWeek{
-		Analysis: new(Analysis),
+		Analysis: NewAnalysis(predictor.Ticker),
 		Spikes: &SpikeRangeAll{
 			big:   new(SpikeRange),
 			small: new(SpikeRange),

--- a/models/ticker.go
+++ b/models/ticker.go
@@ -11,6 +11,12 @@ type PriceTicker struct {
 	// The purchase price on sunday for this week
 	PurchasePrice int
 
+	// The current price period. We need to support not knowing what the current
+	// price is if we are charting data for someone else's island, but need to give
+	// accurate future price ranges, so we will need to explicitly know from the
+	// user what price period the island is currently in.
+	CurrentPeriod PricePeriod
+
 	// There are 12 buy-price periods in a week, we are going to store the 12 buy prices
 	// in a 12-int array. A price of 'zero' will stand for 'not available'
 	//

--- a/predict_test.go
+++ b/predict_test.go
@@ -20,15 +20,29 @@ func Test100BellPurchase(t *testing.T) {
 	ticker := NewPriceTicker(100, patterns.UNKNOWN)
 
 	expected := &expectedPrediction{
-		MinPrice:        10,
-		GuaranteedPrice: 85,
-		MaxPrice:        600,
+		Prices: PriceRange{
+			Min:        10,
+			Guaranteed: 85,
+			Max:        600,
+		},
+		PricesFuture: PriceRange{
+			Min:        10,
+			Guaranteed: 85,
+			Max:        600,
+		},
 		Fluctuating: &expectedPattern{
-			Chance:            0.35,
-			MinPrice:          40,
-			GuaranteedPrice:   90,
-			MaxPotentialPrice: 140,
-			PossibleWeeks:     56,
+			Chance: 0.35,
+			Prices: PriceRange{
+				Min:        40,
+				Guaranteed: 90,
+				Max:        140,
+			},
+			PricesFuture: PriceRange{
+				Min:        40,
+				Guaranteed: 90,
+				Max:        140,
+			},
+			PossibleWeeks: 56,
 			MinPricePeriods: []models.PricePeriod{
 				2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 			},
@@ -40,11 +54,18 @@ func Test100BellPurchase(t *testing.T) {
 			},
 		},
 		BigSpike: &expectedPattern{
-			Chance:            0.2625,
-			MinPrice:          40,
-			GuaranteedPrice:   200,
-			MaxPotentialPrice: 600,
-			PossibleWeeks:     7,
+			Chance: 0.2625,
+			Prices: PriceRange{
+				Min:        40,
+				Guaranteed: 200,
+				Max:        600,
+			},
+			PricesFuture: PriceRange{
+				Min:        40,
+				Guaranteed: 200,
+				Max:        600,
+			},
+			PossibleWeeks: 7,
 			Spike: expectedSpike{
 				Small:      false,
 				SmallStart: 0,
@@ -58,21 +79,35 @@ func Test100BellPurchase(t *testing.T) {
 			MaxPricePeriods:        []models.PricePeriod{3, 4, 5, 6, 7, 8, 9},
 		},
 		Decreasing: &expectedPattern{
-			Chance:                 0.1375,
-			MinPrice:               30,
-			GuaranteedPrice:        85,
-			MaxPotentialPrice:      90,
+			Chance: 0.1375,
+			Prices: PriceRange{
+				Min:        30,
+				Guaranteed: 85,
+				Max:        90,
+			},
+			PricesFuture: PriceRange{
+				Min:        30,
+				Guaranteed: 85,
+				Max:        90,
+			},
 			PossibleWeeks:          1,
 			MinPricePeriods:        []models.PricePeriod{11},
 			GuaranteedPricePeriods: []models.PricePeriod{0},
 			MaxPricePeriods:        []models.PricePeriod{0},
 		},
 		SmallSpike: &expectedPattern{
-			Chance:            0.25,
-			MinPrice:          10,
-			GuaranteedPrice:   140,
-			MaxPotentialPrice: 200,
-			PossibleWeeks:     8,
+			Chance: 0.25,
+			Prices: PriceRange{
+				Min:        10,
+				Guaranteed: 140,
+				Max:        200,
+			},
+			PricesFuture: PriceRange{
+				Min:        10,
+				Guaranteed: 140,
+				Max:        200,
+			},
+			PossibleWeeks: 8,
 			Spike: expectedSpike{
 				Small:      true,
 				SmallStart: 2,
@@ -112,24 +147,36 @@ func Test100BellPurchaseBigSpike(t *testing.T) {
 	ticker.Prices[2] = 160
 
 	expected := &expectedPrediction{
-		MinPrice:        40,
-		GuaranteedPrice: 200,
-		MaxPrice:        600,
+		Prices: PriceRange{
+			Min:        40,
+			Guaranteed: 200,
+			Max:        600,
+		},
+		PricesFuture: PriceRange{
+			Min:        40,
+			Guaranteed: 200,
+			Max:        600,
+		},
 		Fluctuating: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
 			MaxPricePeriods:        []models.PricePeriod{},
 		},
 		BigSpike: &expectedPattern{
-			Chance:            1.0,
-			MinPrice:          40,
-			GuaranteedPrice:   200,
-			MaxPotentialPrice: 600,
-			PossibleWeeks:     1,
+			Chance: 1.0,
+			Prices: PriceRange{
+				Min:        40,
+				Guaranteed: 200,
+				Max:        600,
+			},
+			PricesFuture: PriceRange{
+				Min:        40,
+				Guaranteed: 200,
+				Max:        600,
+			},
+			PossibleWeeks: 1,
 			Spike: expectedSpike{
 				Small:      false,
 				SmallStart: 0,
@@ -144,8 +191,6 @@ func Test100BellPurchaseBigSpike(t *testing.T) {
 		},
 		Decreasing: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -153,8 +198,6 @@ func Test100BellPurchaseBigSpike(t *testing.T) {
 		},
 		SmallSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -188,14 +231,28 @@ func Test100BellPurchaseFluctuating(t *testing.T) {
 	ticker.Prices[5] = 140
 
 	expected := &expectedPrediction{
-		MinPrice:        40,
-		GuaranteedPrice: 90,
-		MaxPrice:        140,
+		Prices: PriceRange{
+			Min:        40,
+			Guaranteed: 90,
+			Max:        140,
+		},
+		PricesFuture: PriceRange{
+			Min:        40,
+			Guaranteed: 140,
+			Max:        140,
+		},
 		Fluctuating: &expectedPattern{
-			Chance:                 1,
-			MinPrice:               40,
-			GuaranteedPrice:        90,
-			MaxPotentialPrice:      140,
+			Chance: 1,
+			Prices: PriceRange{
+				Min:        40,
+				Guaranteed: 90,
+				Max:        140,
+			},
+			PricesFuture: PriceRange{
+				Min:        40,
+				Guaranteed: 140,
+				Max:        140,
+			},
 			PossibleWeeks:          2,
 			MinPricePeriods:        []models.PricePeriod{8, 11},
 			GuaranteedPricePeriods: []models.PricePeriod{0, 1, 2, 3, 4, 5, 8, 9},
@@ -203,8 +260,6 @@ func Test100BellPurchaseFluctuating(t *testing.T) {
 		},
 		BigSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -212,8 +267,6 @@ func Test100BellPurchaseFluctuating(t *testing.T) {
 		},
 		Decreasing: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -221,8 +274,6 @@ func Test100BellPurchaseFluctuating(t *testing.T) {
 		},
 		SmallSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -250,13 +301,18 @@ func Test100BellPurchaseDecreasing(t *testing.T) {
 	ticker.Prices[7] = 58
 
 	expected := &expectedPrediction{
-		GuaranteedPrice: 85,
-		MinPrice:        37,
-		MaxPrice:        90,
+		Prices: PriceRange{
+			Min:        37,
+			Guaranteed: 85,
+			Max:        90,
+		},
+		PricesFuture: PriceRange{
+			Min:        37,
+			Guaranteed: 58,
+			Max:        58,
+		},
 		Fluctuating: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -264,18 +320,23 @@ func Test100BellPurchaseDecreasing(t *testing.T) {
 		},
 		BigSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
 			MaxPricePeriods:        []models.PricePeriod{},
 		},
 		Decreasing: &expectedPattern{
-			Chance:                 1,
-			MinPrice:               37,
-			GuaranteedPrice:        85,
-			MaxPotentialPrice:      90,
+			Chance: 1,
+			Prices: PriceRange{
+				Min:        37,
+				Guaranteed: 85,
+				Max:        90,
+			},
+			PricesFuture: PriceRange{
+				Min:        37,
+				Guaranteed: 58,
+				Max:        58,
+			},
 			PossibleWeeks:          1,
 			MinPricePeriods:        []models.PricePeriod{11},
 			GuaranteedPricePeriods: []models.PricePeriod{0},
@@ -283,8 +344,6 @@ func Test100BellPurchaseDecreasing(t *testing.T) {
 		},
 		SmallSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -307,13 +366,18 @@ func Test100BellPurchaseSmallSpike(t *testing.T) {
 	ticker.Prices[2] = 199
 
 	expected := &expectedPrediction{
-		MinPrice:        10,
-		GuaranteedPrice: 140,
-		MaxPrice:        200,
+		Prices: PriceRange{
+			Min:        10,
+			Guaranteed: 140,
+			Max:        200,
+		},
+		PricesFuture: PriceRange{
+			Min:        10,
+			Guaranteed: 199,
+			Max:        200,
+		},
 		Fluctuating: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -321,8 +385,6 @@ func Test100BellPurchaseSmallSpike(t *testing.T) {
 		},
 		BigSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -330,19 +392,24 @@ func Test100BellPurchaseSmallSpike(t *testing.T) {
 		},
 		Decreasing: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
 			MaxPricePeriods:        []models.PricePeriod{},
 		},
 		SmallSpike: &expectedPattern{
-			Chance:            1,
-			MinPrice:          10,
-			GuaranteedPrice:   140,
-			MaxPotentialPrice: 200,
-			PossibleWeeks:     1,
+			Chance: 1,
+			Prices: PriceRange{
+				Min:        10,
+				Guaranteed: 140,
+				Max:        200,
+			},
+			PricesFuture: PriceRange{
+				Min:        10,
+				Guaranteed: 199,
+				Max:        200,
+			},
+			PossibleWeeks: 1,
 			Spike: expectedSpike{
 				Small:      true,
 				SmallStart: 2,
@@ -377,15 +444,29 @@ func TestUnknownBellPurchase(t *testing.T) {
 	ticker := NewPriceTicker(0, patterns.UNKNOWN)
 
 	expected := &expectedPrediction{
-		GuaranteedPrice: 77,
-		MinPrice:        9,
-		MaxPrice:        660,
+		Prices: PriceRange{
+			Min:        9,
+			Guaranteed: 77,
+			Max:        660,
+		},
+		PricesFuture: PriceRange{
+			Min:        9,
+			Guaranteed: 77,
+			Max:        660,
+		},
 		Fluctuating: &expectedPattern{
-			Chance:            0.35,
-			MinPrice:          36,
-			GuaranteedPrice:   81,
-			MaxPotentialPrice: 154,
-			PossibleWeeks:     56,
+			Chance: 0.35,
+			Prices: PriceRange{
+				Min:        36,
+				Guaranteed: 81,
+				Max:        154,
+			},
+			PricesFuture: PriceRange{
+				Min:        36,
+				Guaranteed: 81,
+				Max:        154,
+			},
+			PossibleWeeks: 56,
 			MinPricePeriods: []models.PricePeriod{
 				2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 			},
@@ -397,11 +478,18 @@ func TestUnknownBellPurchase(t *testing.T) {
 			},
 		},
 		BigSpike: &expectedPattern{
-			Chance:            0.2625,
-			MinPrice:          36,
-			GuaranteedPrice:   180,
-			MaxPotentialPrice: 660,
-			PossibleWeeks:     7,
+			Chance: 0.2625,
+			Prices: PriceRange{
+				Min:        36,
+				Guaranteed: 180,
+				Max:        660,
+			},
+			PricesFuture: PriceRange{
+				Min:        36,
+				Guaranteed: 180,
+				Max:        660,
+			},
+			PossibleWeeks: 7,
 			Spike: expectedSpike{
 				Small:      false,
 				SmallStart: 0,
@@ -415,21 +503,35 @@ func TestUnknownBellPurchase(t *testing.T) {
 			MaxPricePeriods:        []models.PricePeriod{3, 4, 5, 6, 7, 8, 9},
 		},
 		Decreasing: &expectedPattern{
-			Chance:                 0.1375,
-			MinPrice:               27,
-			GuaranteedPrice:        77,
-			MaxPotentialPrice:      99,
+			Chance: 0.1375,
+			Prices: PriceRange{
+				Min:        27,
+				Guaranteed: 77,
+				Max:        99,
+			},
+			PricesFuture: PriceRange{
+				Min:        27,
+				Guaranteed: 77,
+				Max:        99,
+			},
 			PossibleWeeks:          1,
 			MinPricePeriods:        []models.PricePeriod{11},
 			GuaranteedPricePeriods: []models.PricePeriod{0},
 			MaxPricePeriods:        []models.PricePeriod{0},
 		},
 		SmallSpike: &expectedPattern{
-			Chance:            0.25,
-			MinPrice:          9,
-			GuaranteedPrice:   126,
-			MaxPotentialPrice: 220,
-			PossibleWeeks:     8,
+			Chance: 0.25,
+			Prices: PriceRange{
+				Min:        9,
+				Guaranteed: 126,
+				Max:        220,
+			},
+			PricesFuture: PriceRange{
+				Min:        9,
+				Guaranteed: 126,
+				Max:        220,
+			},
+			PossibleWeeks: 8,
 			Spike: expectedSpike{
 				Small:      true,
 				SmallStart: 2,
@@ -480,24 +582,36 @@ func TestMultiplePossibleMatches(t *testing.T) {
 	ticker.Prices[1] = 82
 
 	expected := &expectedPrediction{
-		GuaranteedPrice: 85,
-		MinPrice:        20,
-		MaxPrice:        600,
+		Prices: PriceRange{
+			Guaranteed: 85,
+			Min:        20,
+			Max:        600,
+		},
+		PricesFuture: PriceRange{
+			Guaranteed: 82,
+			Min:        20,
+			Max:        600,
+		},
 		Fluctuating: &expectedPattern{
 			Chance:                 0.0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
 			MaxPricePeriods:        []models.PricePeriod{},
 		},
 		BigSpike: &expectedPattern{
-			Chance:            0.6725,
-			MinPrice:          40,
-			GuaranteedPrice:   200,
-			MaxPotentialPrice: 600,
-			PossibleWeeks:     6,
+			Chance: 0.6725,
+			Prices: PriceRange{
+				Min:        40,
+				Guaranteed: 200,
+				Max:        600,
+			},
+			PricesFuture: PriceRange{
+				Min:        40,
+				Guaranteed: 200,
+				Max:        600,
+			},
+			PossibleWeeks: 6,
 			Spike: expectedSpike{
 				Small:      false,
 				SmallStart: 0,
@@ -511,21 +625,35 @@ func TestMultiplePossibleMatches(t *testing.T) {
 			MaxPricePeriods:        []models.PricePeriod{4, 5, 6, 7, 8, 9},
 		},
 		Decreasing: &expectedPattern{
-			Chance:                 0.0872,
-			MinPrice:               31,
-			GuaranteedPrice:        85,
-			MaxPotentialPrice:      90,
+			Chance: 0.0872,
+			Prices: PriceRange{
+				Min:        31,
+				Guaranteed: 85,
+				Max:        90,
+			},
+			PricesFuture: PriceRange{
+				Min:        31,
+				Guaranteed: 82,
+				Max:        82,
+			},
 			PossibleWeeks:          1,
 			MinPricePeriods:        []models.PricePeriod{11},
 			GuaranteedPricePeriods: []models.PricePeriod{0},
 			MaxPricePeriods:        []models.PricePeriod{0},
 		},
 		SmallSpike: &expectedPattern{
-			Chance:            0.2404,
-			MinPrice:          20,
-			GuaranteedPrice:   140,
-			MaxPotentialPrice: 200,
-			PossibleWeeks:     6,
+			Chance: 0.2404,
+			Prices: PriceRange{
+				Min:        20,
+				Guaranteed: 140,
+				Max:        200,
+			},
+			PricesFuture: PriceRange{
+				Min:        20,
+				Guaranteed: 140,
+				Max:        200,
+			},
+			PossibleWeeks: 6,
 			Spike: expectedSpike{
 				Small:      true,
 				SmallStart: 4,
@@ -574,13 +702,18 @@ func Test100BellPurchaseUnlikelyLowerBoundPattern(t *testing.T) {
 	ticker.Prices[11] = 30
 
 	expected := &expectedPrediction{
-		MinPrice:        30,
-		GuaranteedPrice: 85,
-		MaxPrice:        90,
+		Prices: PriceRange{
+			Min:        30,
+			Guaranteed: 85,
+			Max:        90,
+		},
+		PricesFuture: PriceRange{
+			Min:        30,
+			Guaranteed: 30,
+			Max:        30,
+		},
 		Fluctuating: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -588,18 +721,23 @@ func Test100BellPurchaseUnlikelyLowerBoundPattern(t *testing.T) {
 		},
 		BigSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
 			MaxPricePeriods:        []models.PricePeriod{},
 		},
 		Decreasing: &expectedPattern{
-			Chance:                 1,
-			MinPrice:               30,
-			GuaranteedPrice:        85,
-			MaxPotentialPrice:      90,
+			Chance: 1,
+			Prices: PriceRange{
+				Min:        30,
+				Guaranteed: 85,
+				Max:        90,
+			},
+			PricesFuture: PriceRange{
+				Min:        30,
+				Guaranteed: 30,
+				Max:        30,
+			},
 			PossibleWeeks:          1,
 			MinPricePeriods:        []models.PricePeriod{11},
 			GuaranteedPricePeriods: []models.PricePeriod{0},
@@ -607,8 +745,6 @@ func Test100BellPurchaseUnlikelyLowerBoundPattern(t *testing.T) {
 		},
 		SmallSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -641,13 +777,18 @@ func Test100BellPurchaseUnlikelyUpperBoundPattern(t *testing.T) {
 	ticker.Prices[11] = 58
 
 	expected := &expectedPrediction{
-		MinPrice:        55,
-		GuaranteedPrice: 85,
-		MaxPrice:        90,
+		Prices: PriceRange{
+			Min:        55,
+			Guaranteed: 85,
+			Max:        90,
+		},
+		PricesFuture: PriceRange{
+			Min:        58,
+			Guaranteed: 58,
+			Max:        58,
+		},
 		Fluctuating: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
@@ -655,18 +796,23 @@ func Test100BellPurchaseUnlikelyUpperBoundPattern(t *testing.T) {
 		},
 		BigSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},
 			MaxPricePeriods:        []models.PricePeriod{},
 		},
 		Decreasing: &expectedPattern{
-			Chance:                 1,
-			MinPrice:               55,
-			GuaranteedPrice:        85,
-			MaxPotentialPrice:      90,
+			Chance: 1,
+			Prices: PriceRange{
+				Min:        55,
+				Guaranteed: 85,
+				Max:        90,
+			},
+			PricesFuture: PriceRange{
+				Min:        58,
+				Guaranteed: 58,
+				Max:        58,
+			},
 			PossibleWeeks:          1,
 			MinPricePeriods:        []models.PricePeriod{11},
 			GuaranteedPricePeriods: []models.PricePeriod{0},
@@ -674,8 +820,6 @@ func Test100BellPurchaseUnlikelyUpperBoundPattern(t *testing.T) {
 		},
 		SmallSpike: &expectedPattern{
 			Chance:                 0,
-			GuaranteedPrice:        0,
-			MaxPotentialPrice:      0,
 			PossibleWeeks:          0,
 			MinPricePeriods:        []models.PricePeriod{},
 			GuaranteedPricePeriods: []models.PricePeriod{},


### PR DESCRIPTION
Collects min, max, and guaranteed values as they apply only to the current & future price periods in addition to the normal overall values

Closes #2 